### PR TITLE
fix: add description field

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.2.4] - 2026-03-19
+
+### Fixed
+
+- **`MiddlewareAgent` missing `description` property** — pydantic-ai added `description` as an abstract property on `AbstractAgent`, causing `MiddlewareAgent` instantiation to fail with `reportAbstractUsage`. Delegates to the wrapped agent with a fallback for older pydantic-ai versions.
+
 ## [0.2.3] - 2026-03-11
 
 ### Fixed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "pydantic-ai-middleware"
-version = "0.2.3"
+version = "0.2.4"
 description = "Simple middleware library for Pydantic-AI - before/after hooks without imposed guardrails structure"
 readme = "README.md"
 license = "MIT"

--- a/src/pydantic_ai_middleware/agent.py
+++ b/src/pydantic_ai_middleware/agent.py
@@ -114,6 +114,10 @@ class MiddlewareAgent(AbstractAgent[AgentDepsT, OutputDataT]):
         return self._wrapped.model
 
     @property
+    def description(self) -> str:
+        return getattr(self._wrapped, "description", "")
+
+    @property
     def name(self) -> str | None:
         return self._wrapped.name
 

--- a/tests/test_agent.py
+++ b/tests/test_agent.py
@@ -132,6 +132,12 @@ class TestMiddlewareAgentProperties:
         middleware_agent = MiddlewareAgent(agent)
         assert middleware_agent.model is model
 
+    def test_description_property(self) -> None:
+        """Test description property delegates to wrapped."""
+        agent = Agent(TestModel(), output_type=str)
+        middleware_agent = MiddlewareAgent(agent)
+        assert isinstance(middleware_agent.description, str)
+
     def test_name_property(self) -> None:
         """Test name property delegates to wrapped."""
         agent = Agent(TestModel(), output_type=str, name="test_agent")

--- a/uv.lock
+++ b/uv.lock
@@ -1244,7 +1244,7 @@ wheels = [
 
 [[package]]
 name = "pydantic-ai-middleware"
-version = "0.2.2"
+version = "0.2.3"
 source = { editable = "." }
 dependencies = [
     { name = "genai-prices" },


### PR DESCRIPTION
## [0.2.4] - 2026-03-19

### Fixed

- **`MiddlewareAgent` missing `description` property** — pydantic-ai added `description` as an abstract property on `AbstractAgent`, causing `MiddlewareAgent` instantiation to fail with `reportAbstractUsage`. Delegates to the wrapped agent with a fallback for older pydantic-ai versions.
