### PR TITLE
Bump minimum  to  for compatibility with async  on toolsets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.3.1] - 2026-03-31
+
+### Changed
+
+- Bump minimum `pydantic-ai-slim` to `>=1.74.0` for compatibility with async `get_instructions` on toolsets
+
 ## [0.3.0] - 2026-03-28
 
 ### Changed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "pydantic-ai-shields"
-version = "0.3.0"
+version = "0.3.1"
 description = "Guardrail capabilities for Pydantic AI — cost tracking, tool permissions, input/output guards"
 readme = "README.md"
 license = "MIT"
@@ -23,7 +23,7 @@ classifiers = [
     "Typing :: Typed",
 ]
 dependencies = [
-    "pydantic-ai-slim>=1.71.0",
+    "pydantic-ai-slim>=1.74.0",
     "pydantic>=2.0",
     "genai-prices>=0.0.49",
 ]


### PR DESCRIPTION
## [0.3.1] - 2026-03-31

### Changed

- Bump minimum `pydantic-ai-slim` to `>=1.74.0` for compatibility with async `get_instructions` on toolsets
