### PR TITLE
chore: release 0.3.3 — consolidated CI action bumps

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,10 +17,10 @@ jobs:
       matrix:
         python-version: ['3.10', '3.13']
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v4
+        uses: astral-sh/setup-uv@v8.1.0
         with:
           enable-cache: true
 
@@ -40,10 +40,10 @@ jobs:
     name: Type Check
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v4
+        uses: astral-sh/setup-uv@v8.1.0
         with:
           enable-cache: true
 
@@ -66,10 +66,10 @@ jobs:
       matrix:
         python-version: ['3.10', '3.11', '3.12', '3.13']
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v4
+        uses: astral-sh/setup-uv@v8.1.0
         with:
           enable-cache: true
 
@@ -89,10 +89,10 @@ jobs:
     name: Build Docs
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v4
+        uses: astral-sh/setup-uv@v8.1.0
         with:
           enable-cache: true
 

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -17,10 +17,10 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v4
+        uses: astral-sh/setup-uv@v8.1.0
         with:
           enable-cache: true
 
@@ -34,7 +34,7 @@ jobs:
         run: uv run mkdocs build
 
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v3
+        uses: actions/upload-pages-artifact@v5
         with:
           path: site
 
@@ -47,4 +47,4 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@v5

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -15,10 +15,10 @@ jobs:
       id-token: write
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v4
+        uses: astral-sh/setup-uv@v8.1.0
         with:
           enable-cache: true
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,19 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.3.3] - 2026-05-24
+
+### Infrastructure
+
+Pure CI / dependency-bot housekeeping — no source-code changes, no behaviour change since 0.3.2. Consolidates the two open Renovate auto-PRs (#27, #28) plus the rate-limited items from the [Dependency Dashboard #29](https://github.com/vstorm-co/pydantic-ai-shields/issues/29) into a single release so downstream consumers see one bump instead of four.
+
+- **CI: bump `actions/checkout` to `v6`** across `ci.yml` (×4), `docs.yml`, `publish.yml` ([#27](https://github.com/vstorm-co/pydantic-ai-shields/pull/27), Renovate auto-PR — folded in here).
+- **CI: bump `actions/deploy-pages` to `v5`** in `docs.yml` ([#28](https://github.com/vstorm-co/pydantic-ai-shields/pull/28), Renovate auto-PR — folded in here).
+- **CI: bump `astral-sh/setup-uv` to `v8.1.0`** across `ci.yml` (×4), `docs.yml`, `publish.yml` — from Dashboard #29 (rate-limited). Pinned to the specific patch because `astral-sh/setup-uv` does not maintain a rolling `v8` tag (only `v8.0.0` / `v8.1.0`; `v7` and earlier do have rolling majors).
+- **CI: bump `actions/upload-pages-artifact` to `v5`** in `docs.yml` — from Dashboard #29 (rate-limited); `v5` has a rolling tag so plain `@v5` is used.
+
+The `ci.yml` test matrix (`['3.10', '3.13']`) is unchanged.
+
 ## [0.3.2] - 2026-05-05
 
 ### Fixed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "pydantic-ai-shields"
-version = "0.3.2"
+version = "0.3.3"
 description = "Guardrail capabilities for Pydantic AI — cost tracking, tool permissions, input/output guards"
 readme = "README.md"
 license = "MIT"


### PR DESCRIPTION
Folds **#27** + **#28** + the rate-limited items from Renovate's [Dependency Dashboard #29](https://github.com/vstorm-co/pydantic-ai-shields/issues/29) into **one** release so downstream consumers see a single bump instead of four.

## Bumps

| Action | From | To | Files | Source |
|---|---|---|---|---|
| `actions/checkout` | `v4` | `v6` | `ci.yml` (×4), `docs.yml`, `publish.yml` | #27 |
| `actions/deploy-pages` | `v4` | `v5` | `docs.yml` | #28 |
| `astral-sh/setup-uv` | `v4` | `v8.1.0` | `ci.yml` (×4), `docs.yml`, `publish.yml` | #29 |
| `actions/upload-pages-artifact` | `v3` | `v5` | `docs.yml` | #29 |

`setup-uv` is pinned to the specific patch — the repo does **not** maintain a rolling `v8` tag (only `v8.0.0` / `v8.1.0` exist; `v7` and earlier do have rolling majors). Same lesson learned in summarization-pydantic-ai#23, pydantic-ai-backend#43, pydantic-ai-todo#25, subagents-pydantic-ai#36.

`upload-pages-artifact@v5` and `deploy-pages@v5` are real rolling tags so they're used as `@v5` directly.

The `ci.yml` test matrix (`['3.10', '3.13']`) is unchanged. Pure CI — no library code touched.

## Closing

Closes #27
Closes #28

## Gate

- `make test` — passed, 100% coverage
- `ruff format --check` + `ruff check` — clean
- `pyright` — 0 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)